### PR TITLE
Fixed flicker on animation completion

### DIFF
--- a/Pod/Classes/RJCircularLoaderView.m
+++ b/Pod/Classes/RJCircularLoaderView.m
@@ -89,6 +89,7 @@
     
     CAAnimationGroup *groupAnimation = [CAAnimationGroup animation];
     groupAnimation.fillMode = kCAFillModeForwards;
+    // Prevent the removal of the animation on completion to fix a flicker.  We will remove it manually after we remove the mask.
     groupAnimation.removedOnCompletion = NO;
     groupAnimation.duration = 1;
     groupAnimation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];

--- a/Pod/Classes/RJCircularLoaderView.m
+++ b/Pod/Classes/RJCircularLoaderView.m
@@ -88,6 +88,8 @@
     [CATransaction commit];
     
     CAAnimationGroup *groupAnimation = [CAAnimationGroup animation];
+    groupAnimation.fillMode = kCAFillModeForwards;
+    groupAnimation.removedOnCompletion = NO;
     groupAnimation.duration = 1;
     groupAnimation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
     
@@ -121,6 +123,7 @@
 - (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag
 {
     self.superview.layer.mask = nil;
+    [self.circlePathLayer removeAllAnimations];
     [self removeFromSuperview];
 }
 


### PR DESCRIPTION
For some reason the path did not seem to be updated when set to the new path inside the transaction block.  The flicker that is seen is actually the mask showing up with the old path right before the mask is set to nil in the animation completion delegate.  There is a timing issue where the mask can still show up for a split second right before the mask is set to nil.  The solution I've come up with is to ensure the the animations are not removed on completion and to remove them manually AFTER the mask is set to nil.  I'm not sure if this is the best solution for this problem, but it does fix the flicker.
